### PR TITLE
Fix component import export error

### DIFF
--- a/resources/js/components/admin-sidebar.tsx
+++ b/resources/js/components/admin-sidebar.tsx
@@ -91,7 +91,7 @@ function AdminSidebarContent() {
                                     variant={isActive ? 'secondary' : 'ghost'}
                                     className={cn('w-full justify-start', isActive && 'bg-secondary text-secondary-foreground')}
                                 >
-                                    <item.icon className="mr-2 h-4 w-4" />
+                                    {item.icon && <item.icon className="mr-2 h-4 w-4" />}
                                     {item.title}
                                 </Button>
                             </Link>


### PR DESCRIPTION
Add conditional rendering for sidebar icons to prevent React error when `item.icon` is undefined.

The "Element type is invalid" React error occurred because some menu items (e.g., "Dashboard", "Categories") did not have an `icon` property, causing React to attempt to render an `undefined` component. The fix ensures icons are only rendered when they are explicitly defined.

---
<a href="https://cursor.com/background-agent?bcId=bc-eab69b35-35e0-4a56-9427-eb8002892035">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eab69b35-35e0-4a56-9427-eb8002892035">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

