### PR TITLE
Fix user undefined error and null listener

### DIFF
--- a/resources/js/components/admin-header.tsx
+++ b/resources/js/components/admin-header.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input';
 import { useInitials } from '@/hooks/use-initials';
 import { type BreadcrumbItem, type User } from '@/types';
 import { Link, router, usePage } from '@inertiajs/react';
-import { BarChart3, Bell, HelpCircle, LogOut, Search, Settings, Shield } from 'lucide-react';
+import { BarChart3, Bell, HelpCircle, LogOut, Search, Settings, Shield, User } from 'lucide-react';
 
 interface AdminHeaderProps {
     breadcrumbs?: BreadcrumbItem[];


### PR DESCRIPTION
Add `User` icon import to fix `ReferenceError: User is not defined` in `admin-header.tsx`.

The `User` icon component was being used in the profile dropdown menu within `AdminHeader` but was not imported from `lucide-react`, causing a runtime error. This change adds the missing import.

---
<a href="https://cursor.com/background-agent?bcId=bc-3eacc044-1ff8-4701-8a23-0649e3a59611">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3eacc044-1ff8-4701-8a23-0649e3a59611">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

