### PR TITLE
Fix duplicate user identifier in admin header

### DIFF
--- a/resources/js/components/admin-header.tsx
+++ b/resources/js/components/admin-header.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input';
 import { useInitials } from '@/hooks/use-initials';
 import { type BreadcrumbItem, type User } from '@/types';
 import { Link, router, usePage } from '@inertiajs/react';
-import { BarChart3, Bell, HelpCircle, LogOut, Search, Settings, Shield, User } from 'lucide-react';
+import { BarChart3, Bell, HelpCircle, LogOut, Search, Settings, Shield, User as UserIcon } from 'lucide-react';
 
 interface AdminHeaderProps {
     breadcrumbs?: BreadcrumbItem[];
@@ -115,7 +115,7 @@ export function AdminHeader({ breadcrumbs = [] }: AdminHeaderProps) {
                             <DropdownMenuGroup>
                                 <DropdownMenuItem asChild>
                                     <Link href={route('profile.edit')} className="flex items-center">
-                                        <User className="mr-2 h-4 w-4" />
+                                        <UserIcon className="mr-2 h-4 w-4" />
                                         <span>Profile</span>
                                     </Link>
                                 </DropdownMenuItem>


### PR DESCRIPTION
Rename `User` icon from `lucide-react` to `UserIcon` to resolve a naming conflict with the `User` type.

---
<a href="https://cursor.com/background-agent?bcId=bc-30be14eb-5c2d-4e83-8bc6-c927aa0daaac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30be14eb-5c2d-4e83-8bc6-c927aa0daaac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

