### PR TITLE
Fix duplicate user identifier in admin header

### DIFF
--- a/resources/js/components/admin-header.tsx
+++ b/resources/js/components/admin-header.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { useInitials } from '@/hooks/use-initials';
-import { type BreadcrumbItem, type User } from '@/types';
+import { type BreadcrumbItem, type User as UserType } from '@/types';
 import { Link, router, usePage } from '@inertiajs/react';
 import { BarChart3, Bell, HelpCircle, LogOut, Search, Settings, Shield, User } from 'lucide-react';
 
@@ -21,7 +21,7 @@ interface AdminHeaderProps {
 }
 
 export function AdminHeader({ breadcrumbs = [] }: AdminHeaderProps) {
-    const page = usePage<{ auth: { user: User } }>();
+    const page = usePage<{ auth: { user: UserType } }>();
     const { auth } = page.props;
     const getInitials = useInitials();
 


### PR DESCRIPTION
Rename `User` type import to `UserType` to resolve naming conflict with `lucide-react` icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-b18108d1-f369-4e62-8773-e9d5f4220288">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b18108d1-f369-4e62-8773-e9d5f4220288">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

