### PR TITLE
Ubah tampilan kelola data institusi menjadi kartu

### DIFF
--- a/app/Http/Controllers/Admin/InstitutionController.php
+++ b/app/Http/Controllers/Admin/InstitutionController.php
@@ -11,15 +11,15 @@ use Inertia\Response;
 class InstitutionController extends Controller
 {
     /**
-     * Menampilkan daftar semua institusi dengan paginasi.
+     * Menampilkan data institusi (hanya satu institusi).
      */
     public function index(): Response
     {
+        $institution = Institution::withCount('courses')->first();
+        
         return Inertia::render('admin/institutions/index', [
-            'institutions' => Institution::withCount('courses')
-                ->latest()
-                ->paginate(10)
-                ->withQueryString(),
+            'institution' => $institution,
+            'hasInstitution' => $institution !== null,
         ]);
     }
 
@@ -28,6 +28,12 @@ class InstitutionController extends Controller
      */
     public function create(): Response
     {
+        // Cek apakah sudah ada institusi
+        if (Institution::count() > 0) {
+            return redirect()->route('admin.institutions.index')
+                ->with('error', 'Hanya dapat membuat satu data institusi.');
+        }
+
         return Inertia::render('admin/institutions/create');
     }
 
@@ -36,8 +42,14 @@ class InstitutionController extends Controller
      */
     public function store(Request $request)
     {
+        // Cek apakah sudah ada institusi
+        if (Institution::count() > 0) {
+            return redirect()->route('admin.institutions.index')
+                ->with('error', 'Hanya dapat membuat satu data institusi.');
+        }
+
         $validated = $request->validate([
-            'name' => 'required|string|max:255|unique:institutions',
+            'name' => 'required|string|max:255',
             'description' => 'nullable|string',
             'address' => 'nullable|string',
             'phone' => 'nullable|string|max:20',
@@ -48,7 +60,7 @@ class InstitutionController extends Controller
         Institution::create($validated);
 
         return redirect()->route('admin.institutions.index')
-            ->with('success', 'Institusi berhasil dibuat.');
+            ->with('success', 'Data institusi berhasil dibuat.');
     }
 
     /**
@@ -67,7 +79,7 @@ class InstitutionController extends Controller
     public function update(Request $request, Institution $institution)
     {
         $validated = $request->validate([
-            'name' => 'required|string|max:255|unique:institutions,name,' . $institution->id,
+            'name' => 'required|string|max:255',
             'description' => 'nullable|string',
             'address' => 'nullable|string',
             'phone' => 'nullable|string|max:20',
@@ -78,7 +90,7 @@ class InstitutionController extends Controller
         $institution->update($validated);
 
         return redirect()->route('admin.institutions.index')
-            ->with('success', 'Institusi berhasil diperbarui.');
+            ->with('success', 'Data institusi berhasil diperbarui.');
     }
 
     /**
@@ -95,6 +107,6 @@ class InstitutionController extends Controller
         $institution->delete();
 
         return redirect()->route('admin.institutions.index')
-            ->with('success', 'Institusi berhasil dihapus.');
+            ->with('success', 'Data institusi berhasil dihapus.');
     }
 }

--- a/resources/js/pages/admin/institutions/create.tsx
+++ b/resources/js/pages/admin/institutions/create.tsx
@@ -37,9 +37,11 @@ export default function InstitutionCreate({}: InstitutionCreateProps) {
 
             <div className="">
                 <div className="flex items-center mb-6">
-                    <Button variant="ghost" size="sm" className="mr-2">
-                        <ArrowLeft className="h-4 w-4" />
-                    </Button>
+                    <Link href={route('admin.institutions.index')}>
+                        <Button variant="ghost" size="sm" className="mr-2">
+                            <ArrowLeft className="h-4 w-4" />
+                        </Button>
+                    </Link>
                     <h1 className="text-2xl font-bold">Tambah Data Institusi</h1>
                 </div>
 
@@ -126,9 +128,11 @@ export default function InstitutionCreate({}: InstitutionCreateProps) {
                             </div>
 
                             <div className="flex justify-end space-x-2">
-                                <Button type="button" variant="outline">
-                                    Batal
-                                </Button>
+                                <Link href={route('admin.institutions.index')}>
+                                    <Button type="button" variant="outline">
+                                        Batal
+                                    </Button>
+                                </Link>
                                 <Button type="submit" disabled={processing}>
                                     {processing ? 'Menyimpan...' : 'Simpan Data Institusi'}
                                 </Button>

--- a/resources/js/pages/admin/institutions/edit.tsx
+++ b/resources/js/pages/admin/institutions/edit.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import AdminLayout from '@/layouts/admin-layout';
 import { PageProps } from '@/types';
-import { Head, useForm } from '@inertiajs/react';
+import { Head, useForm, Link } from '@inertiajs/react';
 import { ArrowLeft } from 'lucide-react';
 
 interface Institution {
@@ -49,9 +49,11 @@ export default function InstitutionEdit({ institution }: InstitutionEditProps) {
 
             <div className="">
                 <div className="flex items-center mb-6">
-                    <Button variant="ghost" size="sm" className="mr-2">
-                        <ArrowLeft className="h-4 w-4" />
-                    </Button>
+                    <Link href={route('admin.institutions.index')}>
+                        <Button variant="ghost" size="sm" className="mr-2">
+                            <ArrowLeft className="h-4 w-4" />
+                        </Button>
+                    </Link>
                     <h1 className="text-2xl font-bold">Edit Data Institusi</h1>
                 </div>
 
@@ -137,11 +139,13 @@ export default function InstitutionEdit({ institution }: InstitutionEditProps) {
                             </div>
 
                             <div className="flex justify-end space-x-2">
-                                <Button type="button" variant="outline">
-                                    Batal
-                                </Button>
+                                <Link href={route('admin.institutions.index')}>
+                                    <Button type="button" variant="outline">
+                                        Batal
+                                    </Button>
+                                </Link>
                                 <Button type="submit" disabled={processing}>
-                                    {processing ? 'Menyimpan...' : 'Update Institusi'}
+                                    {processing ? 'Menyimpan...' : 'Update Data Institusi'}
                                 </Button>
                             </div>
                         </form>

--- a/resources/js/pages/admin/institutions/index.tsx
+++ b/resources/js/pages/admin/institutions/index.tsx
@@ -1,12 +1,10 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import AdminLayout from '@/layouts/admin-layout';
-import { PageProps, PaginatedData } from '@/types';
-import { Head, Link } from '@inertiajs/react';
-import { Plus, Edit, Trash2, Mail, Phone, Globe } from 'lucide-react';
-import { Pagination } from '@/components/pagination';
+import { PageProps } from '@/types';
+import { Head, Link, router } from '@inertiajs/react';
+import { Plus, Edit, Trash2, Mail, Phone, Globe, MapPin, Calendar, BookOpen } from 'lucide-react';
 
 interface Institution {
     id: number;
@@ -21,10 +19,11 @@ interface Institution {
 }
 
 interface InstitutionIndexProps extends PageProps {
-    institutions: PaginatedData<Institution>;
+    institution: Institution | null;
+    hasInstitution: boolean;
 }
 
-export default function InstitutionIndex({ institutions }: InstitutionIndexProps) {
+export default function InstitutionIndex({ institution, hasInstitution }: InstitutionIndexProps) {
     return (
         <AdminLayout
             breadcrumbs={[
@@ -39,90 +38,156 @@ export default function InstitutionIndex({ institutions }: InstitutionIndexProps
                     <div>
                         <h1 className="text-2xl font-bold">Kelola Data Institusi</h1>
                         <p className="text-muted-foreground">
-                            Kelola informasi institusi yang terkait dengan kursus pribadi Anda
+                            Kelola informasi institusi untuk website online course Anda
                         </p>
                     </div>
-                    <Link href={route('admin.institutions.create')}>
-                        <Button>
-                            <Plus className="h-4 w-4 mr-2" />
-                            Tambah Data Institusi
-                        </Button>
-                    </Link>
+                    {!hasInstitution && (
+                        <Link href={route('admin.institutions.create')}>
+                            <Button>
+                                <Plus className="h-4 w-4 mr-2" />
+                                Tambah Data Institusi
+                            </Button>
+                        </Link>
+                    )}
                 </div>
 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Data Institusi</CardTitle>
-                        <p className="text-sm text-muted-foreground">
-                            Daftar institusi yang terdaftar dalam sistem kursus Anda
-                        </p>
-                    </CardHeader>
-                    <CardContent>
-                        <Table>
-                            <TableHeader>
-                                <TableRow>
-                                    <TableHead>Nama</TableHead>
-                                    <TableHead>Kontak</TableHead>
-                                    <TableHead>Alamat</TableHead>
-                                    <TableHead>Jumlah Kursus</TableHead>
-                                    <TableHead>Tanggal Dibuat</TableHead>
-                                    <TableHead>Aksi</TableHead>
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {institutions.data.map((institution) => (
-                                    <TableRow key={institution.id}>
-                                        <TableCell className="font-medium">{institution.name}</TableCell>
-                                        <TableCell>
-                                            <div className="space-y-1">
-                                                {institution.email && (
-                                                    <div className="flex items-center text-sm">
-                                                        <Mail className="h-3 w-3 mr-1" />
-                                                        {institution.email}
-                                                    </div>
-                                                )}
-                                                {institution.phone && (
-                                                    <div className="flex items-center text-sm">
-                                                        <Phone className="h-3 w-3 mr-1" />
-                                                        {institution.phone}
-                                                    </div>
-                                                )}
-                                                {institution.website && (
-                                                    <div className="flex items-center text-sm">
-                                                        <Globe className="h-3 w-3 mr-1" />
-                                                        {institution.website}
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </TableCell>
-                                        <TableCell>{institution.address || '-'}</TableCell>
-                                        <TableCell>
-                                            <Badge variant="secondary">{institution.courses_count}</Badge>
-                                        </TableCell>
-                                        <TableCell>{new Date(institution.created_at).toLocaleDateString()}</TableCell>
-                                        <TableCell>
-                                            <div className="flex space-x-2">
-                                                <Link href={route('admin.institutions.edit', institution.id)}>
-                                                    <Button variant="outline" size="sm">
-                                                        <Edit className="h-4 w-4" />
-                                                    </Button>
-                                                </Link>
-                                                <Button variant="destructive" size="sm">
-                                                    <Trash2 className="h-4 w-4" />
-                                                </Button>
-                                            </div>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                        {institutions.links && institutions.links.length > 0 && (
-                            <div className="mt-4">
-                                <Pagination links={institutions.links} />
+                {hasInstitution && institution ? (
+                    <Card className="max-w-4xl">
+                        <CardHeader>
+                            <div className="flex justify-between items-start">
+                                <div>
+                                    <CardTitle className="text-2xl">{institution.name}</CardTitle>
+                                    <p className="text-sm text-muted-foreground mt-1">
+                                        Data institusi untuk website online course Anda
+                                    </p>
+                                </div>
+                                <div className="flex space-x-2">
+                                    <Link href={route('admin.institutions.edit', institution.id)}>
+                                        <Button variant="outline" size="sm">
+                                            <Edit className="h-4 w-4 mr-2" />
+                                            Edit
+                                        </Button>
+                                    </Link>
+                                    <Button 
+                                        variant="destructive" 
+                                        size="sm"
+                                        onClick={() => {
+                                            if (confirm('Apakah Anda yakin ingin menghapus data institusi ini?')) {
+                                                router.delete(route('admin.institutions.destroy', institution.id));
+                                            }
+                                        }}
+                                    >
+                                        <Trash2 className="h-4 w-4 mr-2" />
+                                        Hapus
+                                    </Button>
+                                </div>
                             </div>
-                        )}
-                    </CardContent>
-                </Card>
+                        </CardHeader>
+                        <CardContent className="space-y-6">
+                            {/* Deskripsi */}
+                            {institution.description && (
+                                <div>
+                                    <h3 className="font-semibold text-lg mb-2">Deskripsi</h3>
+                                    <p className="text-muted-foreground">{institution.description}</p>
+                                </div>
+                            )}
+
+                            {/* Informasi Kontak */}
+                            <div>
+                                <h3 className="font-semibold text-lg mb-3">Informasi Kontak</h3>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    {institution.email && (
+                                        <div className="flex items-center space-x-3 p-3 bg-muted/50 rounded-lg">
+                                            <Mail className="h-5 w-5 text-muted-foreground" />
+                                            <div>
+                                                <p className="text-sm font-medium">Email</p>
+                                                <p className="text-sm text-muted-foreground">{institution.email}</p>
+                                            </div>
+                                        </div>
+                                    )}
+                                    {institution.phone && (
+                                        <div className="flex items-center space-x-3 p-3 bg-muted/50 rounded-lg">
+                                            <Phone className="h-5 w-5 text-muted-foreground" />
+                                            <div>
+                                                <p className="text-sm font-medium">Telepon</p>
+                                                <p className="text-sm text-muted-foreground">{institution.phone}</p>
+                                            </div>
+                                        </div>
+                                    )}
+                                    {institution.website && (
+                                        <div className="flex items-center space-x-3 p-3 bg-muted/50 rounded-lg">
+                                            <Globe className="h-5 w-5 text-muted-foreground" />
+                                            <div>
+                                                <p className="text-sm font-medium">Website</p>
+                                                <a 
+                                                    href={institution.website} 
+                                                    target="_blank" 
+                                                    rel="noopener noreferrer"
+                                                    className="text-sm text-blue-600 hover:underline"
+                                                >
+                                                    {institution.website}
+                                                </a>
+                                            </div>
+                                        </div>
+                                    )}
+                                    {institution.address && (
+                                        <div className="flex items-center space-x-3 p-3 bg-muted/50 rounded-lg">
+                                            <MapPin className="h-5 w-5 text-muted-foreground" />
+                                            <div>
+                                                <p className="text-sm font-medium">Alamat</p>
+                                                <p className="text-sm text-muted-foreground">{institution.address}</p>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+
+                            {/* Statistik */}
+                            <div>
+                                <h3 className="font-semibold text-lg mb-3">Statistik</h3>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div className="flex items-center space-x-3 p-3 bg-muted/50 rounded-lg">
+                                        <BookOpen className="h-5 w-5 text-muted-foreground" />
+                                        <div>
+                                            <p className="text-sm font-medium">Total Kursus</p>
+                                            <p className="text-2xl font-bold">{institution.courses_count}</p>
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center space-x-3 p-3 bg-muted/50 rounded-lg">
+                                        <Calendar className="h-5 w-5 text-muted-foreground" />
+                                        <div>
+                                            <p className="text-sm font-medium">Tanggal Dibuat</p>
+                                            <p className="text-sm text-muted-foreground">
+                                                {new Date(institution.created_at).toLocaleDateString('id-ID', {
+                                                    year: 'numeric',
+                                                    month: 'long',
+                                                    day: 'numeric'
+                                                })}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </CardContent>
+                    </Card>
+                ) : (
+                    <Card className="max-w-2xl">
+                        <CardHeader>
+                            <CardTitle>Belum Ada Data Institusi</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                Anda belum memiliki data institusi. Silakan tambahkan data institusi untuk website online course Anda.
+                            </p>
+                        </CardHeader>
+                        <CardContent>
+                            <Link href={route('admin.institutions.create')}>
+                                <Button>
+                                    <Plus className="h-4 w-4 mr-2" />
+                                    Tambah Data Institusi
+                                </Button>
+                            </Link>
+                        </CardContent>
+                    </Card>
+                )}
             </div>
         </AdminLayout>
     );


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor institution management to support a single institution with a card-based UI.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application is designed for a single, private online course institution, making a multi-institution table view and the ability to add multiple records redundant. This change enforces the single institution constraint and provides a more suitable, user-friendly card display for its details.

---
<a href="https://cursor.com/background-agent?bcId=bc-02ab4723-d227-4078-ab50-175009a4b280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02ab4723-d227-4078-ab50-175009a4b280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

