### PR TITLE
Sesuaikan halaman error admin

### DIFF
--- a/SOLUTION_ERROR_403_CUSTOM_STYLING.md
+++ b/SOLUTION_ERROR_403_CUSTOM_STYLING.md
@@ -1,0 +1,143 @@
+# Solusi: Custom Error Page untuk Akses Admin
+
+## Masalah
+Saat user login dan mencoba mengakses route admin tanpa permission, halaman error yang ditampilkan masih menggunakan default styling Laravel, bukan custom styling yang sudah dibuat.
+
+## Penyebab
+1. **RoleMiddleware menggunakan `abort(403, ...)`** - Ini bisa menyebabkan konflik dengan error handling
+2. **Exception handler tidak konsisten** - Pesan error tidak seragam
+3. **Styling error page kurang menarik** - Perlu peningkatan visual
+
+## Solusi yang Diterapkan
+
+### 1. Perbaikan RoleMiddleware
+**File**: `app/Http/Middleware/RoleMiddleware.php`
+
+**Perubahan**:
+- Mengganti `abort(403, ...)` dengan `throw new AuthorizationException(...)`
+- Menambahkan import `AuthorizationException`
+- Memastikan exception handler yang tepat dipanggil
+
+```php
+// Sebelum
+if (!in_array($userRole, $roles)) {
+    abort(403, 'Anda tidak memiliki izin untuk mengakses halaman ini.');
+}
+
+// Sesudah
+if (!in_array($userRole, $roles)) {
+    throw new AuthorizationException('Anda tidak memiliki izin untuk mengakses halaman ini.');
+}
+```
+
+### 2. Perbaikan Exception Handler
+**File**: `app/Exceptions/Handler.php`
+
+**Perubahan**:
+- Memperbaiki pesan error untuk AuthorizationException
+- Menambahkan pesan yang lebih informatif
+
+```php
+if ($e instanceof AuthorizationException) {
+    return Inertia::render('errors/403', [
+        'code' => '403',
+        'title' => 'Akses Dilarang',
+        'description' => 'Anda tidak memiliki izin untuk mengakses halaman ini. Silakan hubungi administrator jika Anda yakin ini adalah kesalahan.',
+    ])->toResponse($request)->setStatusCode(403);
+}
+```
+
+### 3. Perbaikan Fallback Route
+**File**: `routes/web.php`
+
+**Perubahan**:
+- Memperbaiki pesan error di fallback route
+- Memastikan konsistensi pesan error
+
+### 4. Peningkatan Styling ErrorPage Component
+**File**: `resources/js/components/ErrorPage.tsx`
+
+**Perubahan**:
+- Menambahkan gradient background yang lebih menarik
+- Meningkatkan ukuran card dan spacing
+- Menambahkan efek visual yang lebih modern
+- Memperbaiki styling tombol dan icon
+
+**Fitur Baru**:
+- Background gradient yang lebih menarik
+- Card dengan shadow dan backdrop blur
+- Icon dengan background gradient
+- Tombol dengan gradient styling
+- Typography yang lebih besar dan bold
+
+### 5. Peningkatan 403 Error Page
+**File**: `resources/js/pages/errors/403.tsx`
+
+**Perubahan**:
+- Menambahkan icon AlertTriangle sebagai overlay
+- Membuat icon lebih informatif dan menarik
+
+## Cara Testing
+
+### 1. Test dengan User Non-Admin
+1. Login dengan user yang memiliki role `user` (bukan admin)
+2. Coba akses halaman admin: `/admin/dashboard`
+3. Seharusnya muncul custom error page 403 dengan styling yang menarik
+
+### 2. Test dengan Route Testing
+1. Akses URL: `/errors/403`
+2. Pastikan halaman menampilkan styling custom
+
+### 3. Test dengan Middleware
+1. Pastikan RoleMiddleware terdaftar di `bootstrap/app.php`
+2. Test akses ke route yang dilindungi middleware role
+
+## Konfigurasi yang Diperlukan
+
+### 1. Environment Variables
+Pastikan di file `.env`:
+```env
+APP_DEBUG=false
+APP_ENV=production
+```
+
+### 2. Clear Cache (jika diperlukan)
+```bash
+php artisan config:clear
+php artisan route:clear
+php artisan view:clear
+php artisan cache:clear
+```
+
+## Expected Result
+
+Setelah perbaikan, error 403 seharusnya menampilkan:
+- ✅ Custom error page dengan design yang menarik
+- ✅ Background gradient yang modern
+- ✅ Icon Shield dengan AlertTriangle overlay
+- ✅ Pesan error yang informatif dan konsisten
+- ✅ Tombol navigasi yang berguna (Kembali dan Beranda)
+- ✅ Tidak ada stack trace atau debug information
+- ✅ Responsive design untuk mobile dan desktop
+
+## Troubleshooting
+
+Jika masih menggunakan default Laravel error page:
+
+1. **Periksa APP_DEBUG**: Pastikan `APP_DEBUG=false` di `.env`
+2. **Clear Cache**: Jalankan semua perintah clear cache
+3. **Restart Server**: Restart server development
+4. **Periksa Console**: Lihat error di console browser
+5. **Periksa Network**: Lihat response dari server di network tab
+
+## File yang Dimodifikasi
+
+1. `app/Http/Middleware/RoleMiddleware.php` - Perbaikan exception handling
+2. `app/Exceptions/Handler.php` - Perbaikan pesan error
+3. `routes/web.php` - Perbaikan fallback route
+4. `resources/js/components/ErrorPage.tsx` - Peningkatan styling
+5. `resources/js/pages/errors/403.tsx` - Peningkatan icon dan visual
+
+## Kesimpulan
+
+Dengan perbaikan ini, sekarang ketika user mencoba mengakses route admin tanpa permission, mereka akan melihat custom error page yang menarik dan informatif, bukan default Laravel error page. Styling sudah ditingkatkan dengan gradient, shadow, dan visual effects yang modern.

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -66,7 +66,7 @@ class Handler extends ExceptionHandler
                 return Inertia::render('errors/403', [
                     'code' => '403',
                     'title' => 'Akses Dilarang',
-                    'description' => 'Anda tidak memiliki izin untuk mengakses halaman ini.',
+                    'description' => 'Anda tidak memiliki izin untuk mengakses halaman ini. Silakan hubungi administrator jika Anda yakin ini adalah kesalahan.',
                 ])->toResponse($request)->setStatusCode(403);
             }
 

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class RoleMiddleware
 {
@@ -20,7 +21,8 @@ class RoleMiddleware
         $userRole = $request->user()->role;
 
         if (!in_array($userRole, $roles)) {
-            abort(403, 'Anda tidak memiliki izin untuk mengakses halaman ini.');
+            // Throw AuthorizationException instead of using abort() to ensure proper error handling
+            throw new AuthorizationException('Anda tidak memiliki izin untuk mengakses halaman ini.');
         }
 
         return $next($request);

--- a/resources/js/components/ErrorPage.tsx
+++ b/resources/js/components/ErrorPage.tsx
@@ -26,39 +26,41 @@ export default function ErrorPage({
   customActions,
 }: ErrorPageProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center p-4">
-      <div className="w-full max-w-md">
-        <Card className="shadow-xl border-0 bg-white/80 backdrop-blur-sm">
-          <CardHeader className="text-center pb-6">
-            <div className="flex justify-center mb-4">
-              {icon}
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-lg">
+        <Card className="shadow-2xl border-0 bg-white/90 backdrop-blur-md rounded-2xl overflow-hidden">
+          <CardHeader className="text-center pb-6 bg-gradient-to-r from-slate-50 to-blue-50">
+            <div className="flex justify-center mb-6">
+              <div className="p-4 rounded-full bg-gradient-to-br from-red-50 to-orange-50 border-2 border-orange-200">
+                {icon}
+              </div>
             </div>
-            <div className="space-y-2">
-              <CardTitle className="text-6xl font-bold text-slate-800">
+            <div className="space-y-3">
+              <CardTitle className="text-7xl font-black text-transparent bg-clip-text bg-gradient-to-r from-slate-800 to-slate-600">
                 {code}
               </CardTitle>
-              <h2 className="text-xl font-semibold text-slate-700">{title}</h2>
+              <h2 className="text-2xl font-bold text-slate-700">{title}</h2>
             </div>
           </CardHeader>
-          <CardContent className="text-center space-y-6">
-            <p className="text-slate-600 leading-relaxed">{description}</p>
+          <CardContent className="text-center space-y-8 p-8">
+            <p className="text-slate-600 leading-relaxed text-lg">{description}</p>
             
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
               {showBackButton && (
                 <Button
                   variant="outline"
                   onClick={() => window.history.back()}
-                  className="flex items-center gap-2"
+                  className="flex items-center gap-2 px-6 py-3 text-base font-medium"
                 >
-                  <ArrowLeft className="h-4 w-4" />
+                  <ArrowLeft className="h-5 w-5" />
                   Kembali
                 </Button>
               )}
               
               {showHomeButton && (
-                <Button asChild className="flex items-center gap-2">
+                <Button asChild className="flex items-center gap-2 px-6 py-3 text-base font-medium bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700">
                   <Link href="/">
-                    <Home className="h-4 w-4" />
+                    <Home className="h-5 w-5" />
                     Beranda
                   </Link>
                 </Button>
@@ -68,9 +70,9 @@ export default function ErrorPage({
                 <Button
                   variant="outline"
                   onClick={() => window.location.reload()}
-                  className="flex items-center gap-2"
+                  className="flex items-center gap-2 px-6 py-3 text-base font-medium"
                 >
-                  <RefreshCw className="h-4 w-4" />
+                  <RefreshCw className="h-5 w-5" />
                   Muat Ulang
                 </Button>
               )}

--- a/resources/js/pages/errors/403.tsx
+++ b/resources/js/pages/errors/403.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Head } from '@inertiajs/react';
 import ErrorPage from '@/components/ErrorPage';
-import { Shield, Lock, Home, ArrowLeft } from 'lucide-react';
+import { Shield, Lock, Home, ArrowLeft, AlertTriangle } from 'lucide-react';
 
 export default function Forbidden() {
   return (
@@ -11,7 +11,12 @@ export default function Forbidden() {
         code="403"
         title="Akses Dilarang"
         description="Maaf, Anda tidak memiliki izin untuk mengakses halaman ini. Silakan hubungi administrator jika Anda yakin ini adalah kesalahan."
-        icon={<Shield className="h-16 w-16 text-orange-500" />}
+        icon={
+          <div className="relative">
+            <Shield className="h-16 w-16 text-orange-500" />
+            <AlertTriangle className="h-6 w-6 text-red-500 absolute -top-1 -right-1" />
+          </div>
+        }
         showHomeButton={true}
         showBackButton={true}
         showRefreshButton={false}

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,7 +91,7 @@ Route::fallback(function () {
         return Inertia::render('errors/403', [
             'code' => '403',
             'title' => 'Akses Dilarang',
-            'description' => 'Anda tidak memiliki izin untuk mengakses halaman ini.',
+            'description' => 'Anda tidak memiliki izin untuk mengakses halaman ini. Silakan hubungi administrator jika Anda yakin ini adalah kesalahan.',
         ])->toResponse(request())->setStatusCode(403);
     }
     


### PR DESCRIPTION
Display custom-styled 403 error page for unauthorized admin access instead of the default Laravel page.

The `RoleMiddleware` was updated to throw an `AuthorizationException` instead of using `abort(403)`, ensuring the custom exception handler correctly renders the Inertia-based error page. Additionally, the error pages (`ErrorPage.tsx` and `403.tsx`) received visual enhancements for a better user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-f69677db-5df4-416a-8174-3d8ba35eae83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f69677db-5df4-416a-8174-3d8ba35eae83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

